### PR TITLE
fix(serve): port regex for url without trailing slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,9 +143,7 @@ module.exports = (api, options) => {
         process.env.HOST ||
         projectDevServerOptions.host ||
         '0.0.0.0'
-      let port = url.match(/:\d{4}\//)[0]
-      // Remove leading ":" and trailing "/"
-      port = port.substr(1, port.length - 2)
+      let port = url.match(/:(\d{2,4})\/?/)[1]
 
       let networkUrl = getLanUrl(protocol, host, port, options.baseUrl)
       if (!networkUrl && platform === 'android') {


### PR DESCRIPTION
If the serve url doesn't include a trailing slash the command fails.

New regex matches only the port digits without leading `:` and trailing `/`.

Also changed possible length of port to 2 - 4 digits to also enable non 4 digit ports.